### PR TITLE
updatehub: Bump revision to ba71f67

### DIFF
--- a/recipes-core/updatehub/updatehub_git.bb
+++ b/recipes-core/updatehub/updatehub_git.bb
@@ -12,7 +12,7 @@ SRC_URI = " \
     file://updatehub.service \
 "
 
-SRCREV = "d017bd0d140e6752c7228c3b0e6ecaa654b16dff"
+SRCREV = "ba71f676d3c2979aebe9d8f679eefd3559346aa2"
 
 PV = "0.0+${SRCPV}"
 
@@ -32,7 +32,8 @@ do_configure_prepend() {
 }
 
 do_compile() {
-    (cd ${B}/src/${GO_SRCROOT}; ${GO} install ${GO_LINKSHARED} ${GOBUILDFLAGS} ./)
+    (cd ${B}/src/${GO_SRCROOT}/cmd/updatehub; ${GO} install ${GO_LINKSHARED} ${GOBUILDFLAGS} ./)
+    (cd ${B}/src/${GO_SRCROOT}/cmd/updatehub-server; ${GO} install ${GO_LINKSHARED} ${GOBUILDFLAGS} ./)
 }
 
 do_install_append() {
@@ -42,6 +43,9 @@ do_install_append() {
         install -Dm 0755 ${S}/updatehub.initd ${D}/${sysconfdir}/init.d/updatehub
     fi
 }
+
+PACKAGES =+ "${PN}-server"
+FILES_${PN}-server += "${bindir}/${PN}-server"
 
 RDEPENDS_${PN} += "updatehub-system-inquiry"
 


### PR DESCRIPTION
This revision add updatehub-server package and apply the following
changes:

    - ba71f67 Merge pull request #60 from giulianvivan/architecture-refactoring
    - 3e3e064 architecture refactoring
    - 75de8bd Merge pull request #61 from fbertux/master
    - e1e4a63 constants: Fix UpdateHub settings and metadata path
    - 8ad9903 Merge pull request #59 from giulianvivan/copy-support-for-mode-gid-uid
    - f4e9a6a support "target-mode", "target-uid" and "target-gid" for "copy" handler

Signed-off-by: Fabio Berton <fabio.berton@ossystems.com.br>