### PR TITLE
updatehub: Bump to 6fcc8b1 revision

### DIFF
--- a/recipes-core/updatehub/updatehub_git.bb
+++ b/recipes-core/updatehub/updatehub_git.bb
@@ -12,7 +12,7 @@ SRC_URI = " \
     file://updatehub.service \
 "
 
-SRCREV = "39a94a13330ca44376ece1d95f957f2f4569f798"
+SRCREV = "6fcc8b1ede85c8db43d97078c690e464b88e5985"
 
 PV = "0.0+${SRCPV}"
 


### PR DESCRIPTION
This adds following changes:

6fcc8b1 Update README
a0beb3f Add cancel state transition funcionality
975be98 Add func to determine transition flow for state change
85544ce Update stateChangeCallback to return the next of transition
52692e2 Change to error state when leave callback has failed
e96a324 updatehub-server/udev.rules: Support upper case label

Signed-off-by: Luis Gustavo S. Barreto <gustavo@ossystems.com.br>