### PR TITLE
core/updatehub: use network-online.target for systemd

### DIFF
--- a/recipes-core/updatehub/updatehub/updatehub.service
+++ b/recipes-core/updatehub/updatehub/updatehub.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=updatehub agent
-After=network.target time-sync.target
+After=network-online.target time-sync.target
+Wants=network-online.target
 
 [Service]
 ExecStart=@BINDIR@/updatehub


### PR DESCRIPTION
With systemd, wait for network-online.target (rather than network.target)
before starting updatehub.

In case the network is slow coming up (tested with wlan0 interface on WaRP7),
we have the following message (systemctl status updatehub):

Mar 22 20:32:49 imx7s-warp updatehub[242]: time="2018-03-22T20:32:49Z" level=error msg="probe update request failed:
Post https://api.updatehub.io/upgrades: dial tcp: lookup api.updatehub.io on [2001:4860:4860::8888]:53: dial udp [2001:4860:4860::8888]:53:
connect: network is unreachable"

This commit will ensure that all configured network devices are up
and have an IP address assigned before updatehub is started.

Signed-off-by: Pierre-Jean TEXIER <texier.pj2@gmail.com>