### PR TITLE
updatehub-package-schema: Upgrade 1.0.0 -> 1.0.2

### DIFF
--- a/recipes-core/updatehub/updatehub-package-schema_1.0.2.bb
+++ b/recipes-core/updatehub/updatehub-package-schema_1.0.2.bb
@@ -5,8 +5,8 @@ LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/MIT;md5=0835ad
 
 inherit pypi setuptools3
 
-SRC_URI[md5sum] = "12ce6f38777d11239b15e037520e2fbb"
-SRC_URI[sha256sum] = "09cb2e8cdc13ab472ad115cb124c16c301571d7d6680980ffdfdb4f5e9f05788"
+SRC_URI[md5sum] = "f998eb2f01f2b91c527df0130ec1235a"
+SRC_URI[sha256sum] = "22b277edfb0657c4a95063c4ad5be640ee7eadb788a3142c8446620199ba3e39"
 
 CLEANBROKEN = "1"
 


### PR DESCRIPTION
This includes the following changes:

02afb5f  Release 1.0.2
5eecd7 mender-object: add common fields
f6a81a6 (tag: 1.0.1) Release 1.0.1
d701cc6 mender-object tests: add missing fixture
7086a93 mender-object: run tests
2c68bd6 mender-object: mark mode as required field
a1abc70 Merge pull request #15 from gustavosbarreto/mender
b9579a2 metadata: add mender object
1de8c71 Start 1.0.1 development

Signed-off-by: Pierre-Jean TEXIER <texier.pj2@gmail.com>