### PR TITLE
updatehub-active-inactive-backend-u-boot: bump SRCREV

### DIFF
--- a/recipes-bsp/updatehub-active-inactive-backend/updatehub-active-inactive-backend-u-boot_git.bb
+++ b/recipes-bsp/updatehub-active-inactive-backend/updatehub-active-inactive-backend-u-boot_git.bb
@@ -3,7 +3,7 @@ LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://COPYING;md5=838c366f69b72c5df05c96dff79b35f2"
 
 SRC_URI = "git://github.com/updatehub/active-inactive-backend-u-boot.git;protocol=https"
-SRCREV = "4249f67a80fec383aaf28197aedf875c1c7167d2"
+SRCREV = "e09ef86355dce35704615a0e1e7bec6080c89eb3"
 
 S = "${WORKDIR}/git"
 
@@ -16,6 +16,7 @@ do_configure[noexec] = "1"
 do_install () {
     install -Dm 0755 updatehub-active-get ${D}${bindir}/updatehub-active-get
     install -Dm 0755 updatehub-active-set ${D}${bindir}/updatehub-active-set
+    install -Dm 0755 updatehub-active-validated ${D}${bindir}/updatehub-active-validated
 }
 
 RDEPENDS_${PN} += "u-boot-fw-utils"


### PR DESCRIPTION
This includes the following changes:

30d39a8 updatehub-active-set: initialize bootcount to zero
7beb306 updatehub-active-validated: Added
3a53bdb updatehub-active-set: Make bootcount under environment our default
f467511 Untabify and indent code

Signed-off-by: Pierre-Jean TEXIER <texier.pj2@gmail.com>