### PR TITLE
updatehub-sdk-qt: bump SRCREV

### DIFF
--- a/dynamic-layers/qt5/recipes-updatehub/updatehub-sdk-qt/updatehub-sdk-qt_git.bb
+++ b/dynamic-layers/qt5/recipes-updatehub/updatehub-sdk-qt/updatehub-sdk-qt_git.bb
@@ -2,9 +2,9 @@ DESCRIPTION = "updatehub - SDK for Qt/QML"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=838c366f69b72c5df05c96dff79b35f2"
 
-PV = "1.0.0"
+PV = "1.0.1"
 
-SRCREV = "ea7bd27ecc20d4d74a4959a1bd961c7d1beb0d49"
+SRCREV = "34ac72a61c9e32832dedeb03b33e1eed907af35f"
 SRC_URI = "git://github.com/updatehub/agent-sdk-qt.git"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
This includes the following changes:

7b36922 README: add webengine to example list
0673449 Close socket if arguments is invalid
c7f8175 StateChangeListener: add errorOccurred
66ed5e2 Close unhandled state
c3bd20b Add webengine example
9c083a0 Add State::done method
b684e0d Register metatypes for WebEngine integration

Signed-off-by: Luis Gustavo S. Barreto <gustavo@ossystems.com.br>