### PR TITLE
updatehub: Upgrade to version 1.1.0

### DIFF
--- a/recipes-core/updatehub/updatehub/updatehub-local-update
+++ b/recipes-core/updatehub/updatehub/updatehub-local-update
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+mkdir -p /mnt/updatehub
+mount /dev/$1 /mnt/updatehub
+
+updatehub-ctl probe -f file:///mnt/updatehub

--- a/recipes-core/updatehub/updatehub/updatehub-local-update-systemd.rules
+++ b/recipes-core/updatehub/updatehub/updatehub-local-update-systemd.rules
@@ -1,0 +1,12 @@
+ENV{ID_FS_LABEL}=="updatehub|UPDATEHUB", \
+  ENV{DEVTYPE}=="partition", \
+  ACTION=="add", \
+  SUBSYSTEM=="block", \
+  TAG+="systemd", \
+  ENV{SYSTEMD_WANTS}+="updatehub-local-update@%k.service"
+
+ENV{ID_FS_LABEL}=="updatehub|UPDATEHUB", \
+  ENV{DEVTYPE}=="partition", \
+  ACTION=="remove", \
+  RUN+="/usr/bin/systemd-mount -u /mnt/updatehub", \
+  RUN+="/bin/rm -rf /mnt/updatehub"

--- a/recipes-core/updatehub/updatehub/updatehub-local-update-sysvinit.rules
+++ b/recipes-core/updatehub/updatehub/updatehub-local-update-sysvinit.rules
@@ -1,0 +1,11 @@
+ENV{ID_FS_LABEL}=="updatehub|UPDATEHUB", \
+  ENV{DEVTYPE}=="partition", \
+  ACTION=="add", \
+  SUBSYSTEM=="block", \
+  RUN+="/usr/bin/updatehub-local-update %k"
+
+ENV{ID_FS_LABEL}=="updatehub|UPDATEHUB", \
+  ENV{DEVTYPE}=="partition", \
+  ACTION=="remove", \
+  RUN+="/bin/umount /mnt/updatehub", \
+  RUN+="/bin/rm -rf /mnt/updatehub"

--- a/recipes-core/updatehub/updatehub/updatehub-local-update.service
+++ b/recipes-core/updatehub/updatehub/updatehub-local-update.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Run UpdateHub Local Update
+
+[Service]
+Type=oneshot
+ExecStart=@BINDIR@/updatehub-local-update %i
+
+[Install]
+WantedBy=multi-user.target

--- a/recipes-core/updatehub/updatehub/updatehub.initd
+++ b/recipes-core/updatehub/updatehub/updatehub.initd
@@ -26,20 +26,14 @@ log_end_msg() {
     echo
 }
 
-export DAEMON_ARGS
-
 do_start()
 {
-        rm -f /tmp/.stop-updatehub
-        (while [ ! -f /tmp/.stop-updatehub ]; do
-        start-stop-daemon --start --quiet --pidfile $PIDFILE --make-pidfile \
-                          --startas /bin/sh -- -c @LIBDIR@/updatehub/updatehub.start || sleep 1
-        done ; rm -f /tmp/.stop-updatehub) &
+        start-stop-daemon --start --background --quiet --pidfile $PIDFILE --make-pidfile \
+        --startas /bin/sh -- -c "$DAEMON $DAEMON_ARGS" || return 2
 }
 
 do_stop()
 {
-        > /tmp/.stop-updatehub
         start-stop-daemon --stop --quiet --retry=TERM/30/KILL/5 --pidfile $PIDFILE --name $NAME
         RETVAL="$?"
         [ "$RETVAL" = 2 ] && return 2
@@ -72,7 +66,6 @@ case "$1" in
   restart|force-reload)
         log_daemon_msg "Restarting $DESC" "$NAME"
         do_stop
-        sleep 3
         case "$?" in
           0|1)
                 do_start

--- a/recipes-core/updatehub/updatehub/updatehub.service
+++ b/recipes-core/updatehub/updatehub/updatehub.service
@@ -4,7 +4,7 @@ After=local-fs.target network.target time-sync.target
 Requires=local-fs.target
 
 [Service]
-ExecStart=@BINDIR@/unshare -m @BINDIR@/updatehub
+ExecStart=@BINDIR@/updatehub
 Restart=on-failure
 
 [Install]

--- a/recipes-core/updatehub/updatehub/updatehub.start
+++ b/recipes-core/updatehub/updatehub/updatehub.start
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-exec unshare -m updatehub "$DAEMON_ARGS"

--- a/recipes-core/updatehub/updatehub_git.bb
+++ b/recipes-core/updatehub/updatehub_git.bb
@@ -1,21 +1,24 @@
 SUMMARY = "A Firmware Over-The-Air agent for Embedded and Industrial Linux-based devices"
 HOMEPAGE = "https://updatehub.io"
-LICENSE = "MIT"
-LIC_FILES_CHKSUM = "file://${S}/src/${GO_IMPORT}/COPYING;md5=21acc3521d288a5d8a4b3fb611a39604"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://${S}/src/${GO_IMPORT}/LICENSE;md5=fa818a259cbed7ce8bc2a22d35a464fc"
 
 DEPENDS_append = " glide-native libarchive upx-native"
 
 GO_IMPORT = "github.com/UpdateHub/updatehub"
 SRC_URI = " \
-    git://${GO_IMPORT};branch=v1.0.x \
+    git://${GO_IMPORT};branch=v1 \
+    file://updatehub-local-update \
+    file://updatehub-local-update-systemd.rules \
+    file://updatehub-local-update-sysvinit.rules \
+    file://updatehub-local-update.service \
     file://updatehub.initd \
     file://updatehub.service \
-    file://updatehub.start \
 "
 
-SRCREV = "da3629a4088a10c1ef36219caf3212106331e7d4"
+SRCREV = "82a74f7b05b5b200b9f5caf611298dfa8a04db7d"
 
-PV = "1.0.18"
+PV = "1.1.0"
 
 inherit go glide systemd update-rc.d pkgconfig
 
@@ -28,13 +31,16 @@ SYSTEMD_SERVICE_${PN} = "${PN}.service"
 INITSCRIPT_NAME = "${PN}"
 INITSCRIPT_PARAMS = "defaults 99"
 
+SYSTEMD_PACKAGE_updatehub-local-update = "updatehub-local-update"
+SYSTEMD_SERVICE_updatehub-local-update = "updatehub-local-update@.service"
+SYSTEMD_AUTO_ENABLE_updatehub-local-update = "disable"
+
 UPX ?= "${STAGING_BINDIR_NATIVE}/upx"
 UPX_ARGS ?= "--best -q"
 
 GO_INSTALL = " \
     ${GO_IMPORT}/cmd/updatehub \
     ${GO_IMPORT}/cmd/updatehub-ctl \
-    ${GO_IMPORT}/cmd/updatehub-server \
 "
 
 GO_LINKMODE_append = " \
@@ -42,42 +48,43 @@ GO_LINKMODE_append = " \
 "
 
 do_install_append() {
-    # updatehub server udev rule for USB mounting
-    install -Dm 0644 ${S}/src/${GO_IMPORT}/cmd/updatehub-server/udev.rules \
-                     ${D}${nonarch_base_libdir}/udev/rules.d/99-updatehub.rules
+    install -Dm 0755 ${WORKDIR}/updatehub-local-update ${D}${bindir}/updatehub-local-update
 
-    # Handle init system integration
-    if ${@bb.utils.contains('DISTRO_FEATURES','systemd','true','false',d)}; then
-        install -Dm 0644 ${WORKDIR}/updatehub.service ${D}${systemd_unitdir}/system/updatehub.service
-        sed -i -e 's,@BINDIR@,${bindir},g' ${D}${systemd_unitdir}/system/updatehub.service
-    fi
+    # Handle init system integration and updatehub local update udev rule for USB mounting
     if ${@bb.utils.contains('DISTRO_FEATURES','sysvinit','true','false',d)}; then
-        install -Dm 0755 ${WORKDIR}/updatehub.initd ${D}/${sysconfdir}/init.d/updatehub
-        install -Dm 0755 ${WORKDIR}/updatehub.start ${D}${libdir}/updatehub/updatehub.start
+        install -Dm 0755 ${WORKDIR}/updatehub.initd ${D}${sysconfdir}/init.d/updatehub
+        install -Dm 0644 ${WORKDIR}/updatehub-local-update-sysvinit.rules ${D}${nonarch_base_libdir}/udev/rules.d/99-updatehub.rules
         sed -i -e 's,@BINDIR@,${bindir},g' \
             -e 's,@LIBDIR@,${libdir},g' \
             -e 's,@LOCALSTATEDIR@,${localstatedir},g' \
             -e 's,@SYSCONFDIR@,${sysconfdir},g' \
             ${D}/${sysconfdir}/init.d/updatehub
     fi
+    if ${@bb.utils.contains('DISTRO_FEATURES','systemd','true','false',d)}; then
+        install -Dm 0644 ${WORKDIR}/updatehub.service ${D}${systemd_system_unitdir}/updatehub.service
+        install -Dm 0644 ${WORKDIR}/updatehub-local-update.service ${D}${systemd_system_unitdir}/updatehub-local-update@.service
+        install -Dm 0644 ${WORKDIR}/updatehub-local-update-systemd.rules ${D}${nonarch_base_libdir}/udev/rules.d/99-updatehub.rules
+        sed -i -e 's,@BINDIR@,${bindir},g' \
+            ${D}${systemd_system_unitdir}/updatehub.service \
+            ${D}${systemd_system_unitdir}/updatehub-local-update@.service
+    fi
 }
 
 apply_upx() {
     ${UPX} ${UPX_ARGS} ${PKGDEST}/${PN}/${bindir}/updatehub
     ${UPX} ${UPX_ARGS} ${PKGDEST}/${PN}-ctl/${bindir}/updatehub-ctl
-    ${UPX} ${UPX_ARGS} ${PKGDEST}/${PN}-server/${bindir}/updatehub-server
 }
 
 PACKAGEFUNCS += "apply_upx"
 
-PACKAGES =+ "${PN}-ctl ${PN}-server ${PN}-local-update"
+PACKAGES =+ "${PN}-ctl ${PN}-local-update"
 
 FILES_${PN}-ctl += "${bindir}/${PN}-ctl"
-FILES_${PN}-server += "${bindir}/${PN}-server"
-FILES_${PN}-local-update += "${nonarch_base_libdir}/udev/rules.d/99-updatehub.rules"
-RDEPENDS_${PN}-local-update += "${PN}-server at"
+FILES_${PN}-local-update += " \
+    ${nonarch_base_libdir}/udev/rules.d/99-updatehub.rules \
+    ${systemd_system_unitdir}/updatehub-local-update@.service \
+"
 
-RDEPENDS_${PN} += "util-linux-unshare"
 RDEPENDS_${PN}-dev += "bash"
 
 BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
This is a major release and includes the following commits since
version 1.0.18:

    - 82a74f7 server: fix unexpected output of probe command
    - bc30091 Add license scan report and status
    - 7dad336 Re-license our code under Apache-2.0
    - da46d03 glide: update dependencies
    - 4d49c07 updatehub-ctl: add host option
    - 9893521 updatehub: move constants file to updatehub package
    - 79c37b2 settings: add ListenSocket to NetworkSettings group
    - edcb7fc server: Prepend dirname to update package filename
    - 030f097 CODE_OF_CONDUCT updated
    - d605650 server: add some log info
    - aa6375a travis: remove go 1.7
    - 60e65c5 server tests: update to use JSONeq instead of Equals
    - 2371008 server: add local_server tests
    - a6eb3ea server: add updatepackage tests
    - 5a10087 ctl: add --from option
    - cd772fc server: probe updates from a file, directory and http
    - 225f155 server: refactoring
    - d641957 updatehub-server: remove

The above commits reflect in the following changes in the recipe:

  - Remove updatehub-server package: Now updatehub-ctl has the capability
  to probe a file in a URL and update system.
  - Change updatehub-local-update package to use updatehub-ctl: Rework
  udev rules to run updatehub-ctl probe when a USB stick is plugged
  - Remove "at" and "unshare" dependencies: Remove RDEPENDS from
  recipe, and change related files to not use these utilities.
  - Update license checksum: UpdateHub is re-license under Apache-2.0.

Signed-off-by: Fabio Berton <fabio.berton@ossystems.com.br>