### PR TITLE
u-boot-updatehub-script: Update LIC_FILES_CHKSUM file and md5

### DIFF
--- a/recipes-bsp/u-boot/u-boot-updatehub-script.bb
+++ b/recipes-bsp/u-boot/u-boot-updatehub-script.bb
@@ -1,5 +1,5 @@
 LICENSE = "GPLv2+"
-LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/GPL-2.0;md5=801f80980d171dd6425610833a22dbe6"
+LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/GPL-2.0-or-later;md5=fed54355545ffd980b814dab4a3b312c"
 
 ### U-Boot Script for UpdateHub images
 #


### PR DESCRIPTION
OE-Core commit 5ecf139a added "or later" versions of common license
files, e.g. GPL-2.0-or-later, change LIC_FILES_CHKSUM file and md5
accordingly.

Signed-off-by: Fabio Berton <fabio.berton@ossystems.com.br>