### PR TITLE
updatehub: Remove initscript stop parameter

### DIFF
--- a/recipes-core/updatehub/updatehub_git.bb
+++ b/recipes-core/updatehub/updatehub_git.bb
@@ -33,7 +33,7 @@ SYSTEMD_PACKAGE = "${PN}"
 SYSTEMD_SERVICE_${PN} = "${PN}.service"
 
 INITSCRIPT_NAME = "${PN}"
-INITSCRIPT_PARAMS = "defaults 99"
+INITSCRIPT_PARAMS = "start 99 2 3 4 5 ."
 
 SYSTEMD_PACKAGE_updatehub-local-update = "updatehub-local-update"
 SYSTEMD_SERVICE_updatehub-local-update = "updatehub-local-update@.service"


### PR DESCRIPTION
UpdateHub initscript doesn't need to stop at reboot/shutdown, it only
needs to start correctly.

Signed-off-by: Fabio Berton <fabio.berton@ossystems.com.br>