### PR TITLE
updatehub: Bump revision to cb28a8f

### DIFF
--- a/recipes-core/updatehub/updatehub_git.bb
+++ b/recipes-core/updatehub/updatehub_git.bb
@@ -15,7 +15,7 @@ SRC_URI = " \
     file://updatehub.service \
 "
 
-SRCREV = "03909531414fd4753545555139236860c986e4f5"
+SRCREV = "cb28a8f33b3d08c7c9bd52b90ee19c867bd6d49d"
 
 S = "${WORKDIR}/git/${BPN}"
 


### PR DESCRIPTION
This commit includes the following changes:

    - cb28a8f updatehub: Fix single thread execution
    - 4bc7641 updatehub: Update setup mock env execution string

Signed-off-by: Vinicius Aquino <vinicius.aquino@ossystems.com.br>