### PR TITLE
updatehub: Upgrade to 2.0.3

### DIFF
--- a/recipes-core/updatehub/updatehub_git.bb
+++ b/recipes-core/updatehub/updatehub_git.bb
@@ -15,11 +15,11 @@ SRC_URI = " \
     file://updatehub.service \
 "
 
-SRCREV = "cb28a8f33b3d08c7c9bd52b90ee19c867bd6d49d"
+SRCREV = "eaa440023d2bd6ba9300bb1d2834b39be1c11ff4"
 
 S = "${WORKDIR}/git/${BPN}"
 
-PV = "2.0.2"
+PV = "2.0.3"
 
 inherit cargo systemd update-rc.d pkgconfig
 


### PR DESCRIPTION
Update to 2.0.3 and it includes following changes:

    - 9755e8e updatehub: unify the callback output handling and improve logging
    - 00b2dc9 updatehub: Avoid error loop in case state_change_callback fails
    - e4ab2da updatehub: Add info log entry when running the state change callback
    - f7d8e91 updatehub: Improve log message when starting to handle a state
    - 295645d updatehub: Add log entry when running a callback
    - 634f16a updatehub: runtime_settings: backward compatibility with v1
    - f8b7d4b updatehub: runtime_settings: Rename variant name in Error
    - 0f7ab9c general: Fix needless-borrow lint errors
    - dcf8c8e updatehub: settings: move v1 parsing helpers to utils module
    - 6b78d9d updatehub: runtime_settings: move tests under a module
    - 30fceb0 updatehub: settings: small refactor to simplify code
    - 07b5d1f Upgrade all dependencies
    - 315bcd6 Fix Display formatting error
    - 3631d24 updatehub: Object installing context
    - 251a13b updatehub: Use a `&str` to singature decoding from the `uhupkg` package
    - cb28a8f updatehub: Fix single thread execution
    - 4bc7641 updatehub: Update setup mock env execution string

Signed-off-by: Vinicius Aquino <vinicius.aquino@ossystems.com.br>