### PR TITLE
updatehub: Bump revision to 7cd747e

### DIFF
--- a/recipes-core/updatehub/updatehub_git.bb
+++ b/recipes-core/updatehub/updatehub_git.bb
@@ -15,7 +15,7 @@ SRC_URI = " \
     file://updatehub.service \
 "
 
-SRCREV = "eaa440023d2bd6ba9300bb1d2834b39be1c11ff4"
+SRCREV = "7cd747e253d8dc1274a8e32735da5c2564c6aa38"
 
 S = "${WORKDIR}/git/${BPN}"
 


### PR DESCRIPTION
This commit includes the following change:

    - 7cd747e updatehub: states: Add callback support for PrepareLocalInstall

Signed-off-by: Vinicius Aquino <vinicius.aquino@ossystems.com.br>