### PR TITLE
u-boot-updatehub-script: Allow addition of extra fragments

### DIFF
--- a/recipes-bsp/u-boot/u-boot-updatehub-script.bb
+++ b/recipes-bsp/u-boot/u-boot-updatehub-script.bb
@@ -70,6 +70,28 @@ LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/GPL-2.0-or-lat
 #       root=PARTUUID=\${uuid} rw rootwait \${vidargs}
 #
 #
+# - UPDATEHUB_BOOTSCRIPT_BEFORE_BOOTCMD
+#
+#   Allow inclusion of extra boot script fragment to be run before running the
+#   UPDATEHUB_BOOTSCRIPT_BOOTCMD fragment, for example using `fdt` command to
+#   enable/disable device tree handles.
+#
+#   Example:
+#       fdt addr \${fdt_addr_r}; \
+#       fdt resize; \
+#       if itest.s "x" == "x\${lvds_size}"; then \
+#           lvds_size="10"; \
+#       fi \
+#       \
+#       if itest.s "x10" == "x\${lvds_size}"; then \
+#           fdt set /panel compatible "aison,z101wx02jct736"; \
+#       elif itest.s "x8" == "x\${lvds_size}"; then \
+#           fdt set /panel compatible "aison,z080xg03jct3"; \
+#       else
+#           echo "ERROR: Unknown 'lvds_size'. Valid ones are '10' and '8'."; \
+#       fi
+#
+#
 # - UPDATEHUB_BOOTSCRIPT_BOOTCMD
 #
 #   Boot command to boot board after kernel and dtb are loaded, and initramfs if
@@ -97,6 +119,8 @@ python() {
         if not var:
             raise bb.parse.SkipRecipe("%s variable must be set." % var)
 }
+
+UPDATEHUB_BOOTSCRIPT_BEFORE_BOOTCMD ?= ""
 
 do_generate_bootscript() {
     cat > ${B}/boot.cmd <<EOF
@@ -145,6 +169,11 @@ fi
 
 # Initialize the boot process
 setenv bootargs "${UPDATEHUB_BOOTSCRIPT_BOOTARGS}"
+
+# Extra bootscript fragments
+${UPDATEHUB_BOOTSCRIPT_BEFORE_BOOTCMD}
+
+# Run bootcmd
 ${UPDATEHUB_BOOTSCRIPT_BOOTCMD}
 EOF
 }

--- a/recipes-bsp/u-boot/u-boot-updatehub-script.bb
+++ b/recipes-bsp/u-boot/u-boot-updatehub-script.bb
@@ -178,6 +178,12 @@ ${UPDATEHUB_BOOTSCRIPT_BOOTCMD}
 EOF
 }
 do_generate_bootscript[dirs] = "${B}"
+do_generate_bootscript[vardeps] += " \
+    UPDATEHUB_BOOTSCRIPT_LOAD_A UPDATEHUB_BOOTSCRIPT_LOAD_B \
+    UPDATEHUB_BOOTSCRIPT_FIND_ROOT_A UPDATEHUB_BOOTSCRIPT_FIND_ROOT_B \
+    UPDATEHUB_BOOTSCRIPT_BOOTARGS UPDATEHUB_BOOTSCRIPT_BOOTCMD \
+    UPDATEHUB_BOOTSCRIPT_BEFORE_BOOTCMD \
+"
 
 addtask generate_bootscript after do_configure before do_mkimage
 


### PR DESCRIPTION
Allow inclusion of extra boot script fragment, using
UPDATEHUB_BOOTSCRIPT_BEFORE_BOOTCMD, to be run before running the
UPDATEHUB_BOOTSCRIPT_BOOTCMD fragment, for example using `fdt` command
to enable/disable device tree handles.


Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>