### PR TITLE
updatehub: Bump to 01961ff

### DIFF
--- a/recipes-core/updatehub/updatehub_git.bb
+++ b/recipes-core/updatehub/updatehub_git.bb
@@ -15,7 +15,7 @@ SRC_URI = " \
     file://updatehub.service \
 "
 
-SRCREV = "7cd747e253d8dc1274a8e32735da5c2564c6aa38"
+SRCREV = "01961ffae78e61d9b6445041a85c28c0ebf8823f"
 
 S = "${WORKDIR}/git/${BPN}"
 


### PR DESCRIPTION
Bump to 01961ff revision and it includes the following changes:

    01961ff Upgrade all dependencies
    36d26aa uh: More informative error message for when installation_set::active fails
    085a685 CI: Raise MSRV to 1.52 to avoid cargo cashe errors
    d90be8c CI: Pin down nightly version to avoid execution erros from rexpect

Signed-off-by: Vinicius Aquino <vinicius.aquino@ossystems.com.br>