### PR TITLE
updatehub: Upgrade to 2.0.6

### DIFF
--- a/recipes-core/updatehub/updatehub_git.bb
+++ b/recipes-core/updatehub/updatehub_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://../LICENSE-APACHE;md5=fa818a259cbed7ce8bc2a22d35a464f
 DEPENDS = "libarchive openssl upx-native"
 
 SRC_URI = " \
-    git://github.com/UpdateHub/updatehub \
+    git://github.com/UpdateHub/updatehub;branch=v2.0.x \
     file://updatehub-local-update \
     file://updatehub-local-update-systemd.rules \
     file://updatehub-local-update-sysvinit.rules \
@@ -15,11 +15,11 @@ SRC_URI = " \
     file://updatehub.service \
 "
 
-SRCREV = "01961ffae78e61d9b6445041a85c28c0ebf8823f"
+SRCREV = "10d4483b98986c8e38e6044c7d8b1fcd695cb8fe"
 
 S = "${WORKDIR}/git/${BPN}"
 
-PV = "2.0.3"
+PV = "2.0.6"
 
 inherit cargo systemd update-rc.d pkgconfig
 


### PR DESCRIPTION
Update to 2.0.6 and it includes following changes:

    - 10d4483 (cargo-release) version 2.0.6
    - ee500b9 (cargo-release) version 2.0.6
    - d1d1544 (cargo-release) version 2.0.6
    - 46d17c9 (cargo-release) version 2.0.6
    - ef3b845 general: Update dependencies
    - 19d9ee6 (cargo-release) version 2.0.5
    - eb41cc5 (cargo-release) version 2.0.5
    - f6bb6ed (cargo-release) version 2.0.5
    - 0505562 (cargo-release) version 2.0.5
    - 51a8a4f (cargo-release) version 2.0.4
    - 8bde249 general: Pindown serde to 1.0.128 to avoid publish error

Signed-off-by: Vinicius Aquino <vinicius.aquino@ossystems.com.br>
(cherry picked from commit 5fb9eb0de5b53bec3a59543dda40d7cc0708b1ee)