### PR TITLE
updatehub-local-update: Add loop for try run the updatehub client

### DIFF
--- a/recipes-core/updatehub/updatehub/updatehub-local-update
+++ b/recipes-core/updatehub/updatehub/updatehub-local-update
@@ -5,4 +5,8 @@ mount /dev/$1 @LOCAL_UPDATE_DIR@
 
 uhupkg=$(ls -t @LOCAL_UPDATE_DIR@/*.uhupkg | head -n1)
 
-updatehub client install-package $uhupkg
+for i in $(seq 1 30); do
+    updatehub client install-package $uhupkg && exit 0
+    sleep 1s
+done
+exit 1

--- a/recipes-core/updatehub/updatehub/updatehub-local-update.service
+++ b/recipes-core/updatehub/updatehub/updatehub-local-update.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Run UpdateHub Local Update
+After=updatehub.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Add loop to try to prevent the binary from returning an
error before the updatehub starts running.

Signed-off-by: Luan Rafael Carneiro <luan.rafael@ossystems.com.br>