### PR TITLE
updatehub: Upgrade to 2.1.0

### DIFF
--- a/recipes-core/updatehub/updatehub_git.bb
+++ b/recipes-core/updatehub/updatehub_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://../LICENSE-APACHE;md5=fa818a259cbed7ce8bc2a22d35a464f
 DEPENDS = "libarchive openssl upx-native"
 
 SRC_URI = " \
-    git://github.com/UpdateHub/updatehub;protocol=https;branch=v2.0.x \
+    git://github.com/UpdateHub/updatehub;protocol=https;branch=master \
     file://updatehub-local-update \
     file://updatehub-local-update-systemd.rules \
     file://updatehub-local-update-sysvinit.rules \
@@ -15,11 +15,11 @@ SRC_URI = " \
     file://updatehub.service \
 "
 
-SRCREV = "10d4483b98986c8e38e6044c7d8b1fcd695cb8fe"
+SRCREV = "cf63df6bd138e607a8dbffc2624bfbbe389614a1"
 
 S = "${WORKDIR}/git/${BPN}"
 
-PV = "2.0.6"
+PV = "2.1.0"
 
 inherit cargo systemd update-rc.d pkgconfig
 


### PR DESCRIPTION
This upgrade includes the following commits:

    - c73beb7 general: Update dependencies
    - 1a45761 general: Add serde's missing "std" feature to projects that requires it
    - bc1d335 Revert "general: Pindown serde to 1.0.128 to avoid publish error"
    - 0153562 general: Update cargo-release config file for version 0.19
    - 60d74fd uh: Reworks mount utility function
    - 5e14f1b uh: Add limit to opened device device on install if different for raw object
    - 6e80628 uh: Handle install-if-different with async code
    - da608f7 uh: Fix checksum test
    - cc81587 Revert "CI: Pin down nightly version to avoid execution erros from rexpect"
    - 0b4c21f general: Update to edition 2021, bump MSRV and clippy fixes
    - 9130705 uh: Use Display for formating ExitStatus on callback scripts execution
    - 46c7fd6 uh: Rework download dir on failing_invalid_download_dir
    - ba45151 uh: Use async API on utils module
    - e7a92d5 uh: drop unnecessary Seek restriction to timed io operations on util
    - b3737c7 nix: sort shell.nix dependencies
    - c5a1710 nix: add protobuf to shell.nix
    - 62fa9dd uh: Add flush to delta::clone
    - f98606a uh: apply clippy notes
    - 55d4c37 Revert "CI: Pin down nightly version for aarch64 and armv7 CI due to rexpect bug"
    - b019e8b uh: Update bitar commit lock so UpdateHub cam be built on nightly
    - 0a0b935 uh: Swap rexpect for expectrl for logging collecting on integration tests
    - 4919ea7 general: Remove unused dependencies
    - eafdc14 uh: Move from async-std to tokio
    - bb46014 updatehub-sdk: Move from surf to reqwest
    - c93c5b5 cloud-sdk: Move from async_std + surf to tokio + reqwest
    - d97142a cloud-sdk: Add clone to UpdatePackage
    - a8a418e pkg-schema: Add clone to install objects struct
    - 713df09 uh: Drop unused waker from Addr
    - 245c5b4 CI: Pin down nightly version for aarch64 and armv7 CI due to rexpect bug
    - 19281ce uh: Add log module to utils to easily log Results and Options
    - 0b99591 updatehub: Add support for RawDelta objects
    - 4c7bb1b package-schema: Add RawDelta object
    - 0f571fb uh: utils: Add delta module to handle differential updates
    - 067fa04 uh: installer: Use async methods for object::Installer trait
    - 206ba67 uh: installer: Add object context to check_requirements function
    - 4693663 updatehub: Add support for remote installed objects
    - 98004f4 ci: Run CI on backport branches

Signed-off-by: Vinicius Aquino <vinicius.aquino@ossystems.com.br>
(cherry picked from commit 71ff17602ffa2b079971516c91f1c9ed02b3f940)