### PR TITLE
classes/updatehub-image-tasks.bbclass: Enable network to compilation

### DIFF
--- a/classes/updatehub-image-tasks.bbclass
+++ b/classes/updatehub-image-tasks.bbclass
@@ -195,6 +195,7 @@ addtask uhupush after do_image_complete do_unpack
 do_uhupush[depends] += "uhu-native:do_populate_sysroot"
 do_uhupush[nostamp] = "1"
 do_uhupush[recrdeptask] += "do_deploy"
+do_uhupush[network] = "1"
 
 addtask validate_updatehub_settings before do_uhupush
 addtask validate_updatehub_settings before do_uhuarchive


### PR DESCRIPTION
   After the bitbake revision 0746b6a2, any task which does not have the network flag set will have networking disabled

Signed-off-by: Rodrigo M. Duarte <rodrigo.duarte@ossystems.com.br>