### PR TITLE
updatehub: Update package version 2.1.0 -> 2.1.1

### DIFF
--- a/recipes-core/updatehub/updatehub_git.bb
+++ b/recipes-core/updatehub/updatehub_git.bb
@@ -16,11 +16,11 @@ SRC_URI = " \
     file://0001-Cargo.toml-Remove-panic-directive.patch;patchdir=.. \
 "
 
-SRCREV = "cf63df6bd138e607a8dbffc2624bfbbe389614a1"
+SRCREV = "f2e56bd1602d4a2c3c46391d9d728170c3c5e94e"
 
 S = "${WORKDIR}/git/${BPN}"
 
-PV = "2.1.0"
+PV = "2.1.1"
 
 inherit cargo systemd update-rc.d pkgconfig
 


### PR DESCRIPTION
This commit includes de following changes:
    - f2e56bd (cargo-release) version 2.1.1
    - 69c7849 (cargo-release) version 2.1.1
    - 50c1235 (cargo-release) version 2.1.1
    - 5527f2c (cargo-release) version 2.1.1
    - 385a50f cargo: upgrade dependencies
    - 835f03d cross: use newer libarchive images
    - 5ab607e sdk: api: info: fix response parsing for single items
    - 6a4796b updatehub: installer: imxkobs: avoid allocating extra memory
    - b019cfa updatehub: object: copy: if file is missing, install it
    - 8a4eeb5 nix: start using 'flake' for development environment
    - 1396d24 ci: drop ARMv7 and AArch64 jobs
    - 6bc1a96 nix: avoid using lorri and instead use nix-direnv

Signed-off-by: Luan Rafael Carneiro <luan.rafael@ossystems.com.br>
(cherry picked from commit dbd6292d38a5ef572252855ab8711d5959184914)