### PR TITLE
updatehub_git: New updatehub release

### DIFF
--- a/recipes-core/updatehub/updatehub_git.bb
+++ b/recipes-core/updatehub/updatehub_git.bb
@@ -16,11 +16,11 @@ SRC_URI = " \
     file://0001-Cargo.toml-Remove-panic-directive.patch;patchdir=.. \
 "
 
-SRCREV = "f2e56bd1602d4a2c3c46391d9d728170c3c5e94e"
+SRCREV = "cde534fcdc5318859ac82f25d0d33a3f28b0cacd"
 
 S = "${WORKDIR}/git/${BPN}"
 
-PV = "2.1.1"
+PV = "2.1.2"
 
 inherit cargo systemd update-rc.d pkgconfig
 


### PR DESCRIPTION
This revision applies the following fixes.

cde534f (cargo-release) version 2.1.2
4e16cd1 cargo: logging_content: use 0.1 from crates.io
9b7255c nix: add mtdutils as it is used in excluded tests
4842805 global: add Eq implementation where we have PartialEq
520edd5 updatehub: use validation state in local package installation
2703685 updatehub: find underlying device for UBIFS volumes
Signed-off-by: Rodrigo M. Duarte <rodrigo.duarte@ossystems.com.br>