### PR TITLE
updatehub-sdk-qt: Update revision to 3ed408f

### DIFF
--- a/dynamic-layers/qt5/recipes-updatehub/updatehub-sdk-qt/updatehub-sdk-qt_git.bb
+++ b/dynamic-layers/qt5/recipes-updatehub/updatehub-sdk-qt/updatehub-sdk-qt_git.bb
@@ -2,9 +2,9 @@ DESCRIPTION = "updatehub - SDK for Qt/QML"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=838c366f69b72c5df05c96dff79b35f2"
 
-PV = "1.0.3"
+PV = "2.0.0"
 
-SRCREV = "0c01ccc7f2f061cad2b1d55f42404db45c0321a2"
+SRCREV = "3ed408f772aec11472cf43b94b5c76f856accb37"
 SRC_URI = "git://github.com/updatehub/agent-sdk-qt.git;protocol=https;branch=master"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
Update revision to 3ed408f. This commit includes the following changes:

    - 3ed408f listener: Fix socket path
    - 0ff4401 listener: Replace string to const variable
    - dcac0c8 Implement PrepareLocalInstall state
    - 3d63a3b Simplify the qt api example
    - 0efb7e3 Remove unnecessary statement
    - 087cbb5 Add option to install QML plugin
    - 5f19e66 Add CI tests
    - c1f8217 Upgrade agent to v2
    - f626f50 Indent the source code to padronize it
    - 76900cd Add setDefaultHost method
    - ec27474 Increase icons size
    - 136fa7b Downgrade QtQuickControls version
    - ea45224 Wait 5 seconds before rebooting
    - 91f551e Handle enter state only
    - 7896d4b Bump QtQuickControls version
    - 217fafe Use default server address for probe request
    - b58c326 Remove duplicated property
    - 44abe6a Bump QtQuick version
    - f51539f Fix button size
    - 478fb1a examples: add demo-app

Signed-off-by: Luan Rafael Carneiro <luan.rafael@ossystems.com.br>