### PR TITLE
u-boot-updatehub-script: Update the license name

### DIFF
--- a/recipes-bsp/u-boot/u-boot-updatehub-script.bb
+++ b/recipes-bsp/u-boot/u-boot-updatehub-script.bb
@@ -1,4 +1,4 @@
-LICENSE = "GPLv2+"
+LICENSE = "GPL-2.0-or-later"
 LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/GPL-2.0-or-later;md5=fed54355545ffd980b814dab4a3b312c"
 
 ### U-Boot Script for UpdateHub images


### PR DESCRIPTION
Update the license to avoid warning messages